### PR TITLE
Use maximum size instead of minimum size for scatter-regions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
 
 ### Checklist
-- [ ] Pull request details were added to HISTORY.rst
+- [ ] Pull request details were added to CHANGELOG.rst
+- [ ] Documentation updated (if required)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 ==========
 
+version 1.0.0-dev
+---------------------------
++ scatter-regions now uses maximum size instead of minimum size for its scatter
+  sizes. This leads to a more even distribution.
 
 version 0.2.0
 ---------------------------

--- a/README.md
+++ b/README.md
@@ -88,9 +88,10 @@ optional arguments:
                         This makes the program usable in scripts and
                         worfklows.
   -s SCATTER_SIZE, --scatter-size SCATTER_SIZE
-                        How large the regions over which to scatter should be.
-                        Default: 1000000000.
-
+                        The maximum size for the regions over which to
+                        scatter. If contigs are not split, and a contig is
+                        bigger than the maximum size, the contig will be
+                        placed in its own file. Default: 1000000000.
 ```
 
 ## Examples

--- a/src/chunked_scatter/chunked_scatter.py
+++ b/src/chunked_scatter/chunked_scatter.py
@@ -82,10 +82,10 @@ def chunked_scatter(regions: Iterable[BedRegion],
         # If the next chunk is on a different contig
         if contigs_can_be_split or chunk.contig != current_contig:
             current_contig = chunk.contig
-            # and the current bed file contains enough bases
             # Yield if the minimum is reached, or if current chunk will
             # overflow the size and there is at least one chunk already.
-            size_to_check = current_scatter_size + len(chunk) if size_is_maximum else current_scatter_size
+            size_to_check = (current_scatter_size + len(chunk)
+                             if size_is_maximum else current_scatter_size)
             if size_to_check >= list_size and len(chunk_list) > 0:
                 yield chunk_list
                 chunk_list = []

--- a/src/chunked_scatter/chunked_scatter.py
+++ b/src/chunked_scatter/chunked_scatter.py
@@ -83,13 +83,10 @@ def chunked_scatter(regions: Iterable[BedRegion],
         if contigs_can_be_split or chunk.contig != current_contig:
             current_contig = chunk.contig
             # and the current bed file contains enough bases
-            minimum_reached = current_scatter_size >= list_size
-            maximum_reached = current_scatter_size + len(chunk) >= list_size
             # Yield if the minimum is reached, or if current chunk will
             # overflow the size and there is at least one chunk already.
-            if (minimum_reached and not size_is_maximum) or (
-                    maximum_reached and size_is_maximum and len(chunk_list) > 0
-            ):
+            size_to_check = current_scatter_size + len(chunk) if size_is_maximum else current_scatter_size
+            if size_to_check >= list_size and len(chunk_list) > 0:
                 yield chunk_list
                 chunk_list = []
                 current_scatter_size = 0

--- a/src/chunked_scatter/parsers.py
+++ b/src/chunked_scatter/parsers.py
@@ -32,6 +32,9 @@ class BedRegion(NamedTuple):
     def __str__(self):
         return f"{self.contig}\t{self.start}\t{self.end}"
 
+    def __len__(self):
+        return self.end - self.start
+
 
 def dict_file_to_regions(in_file: Union[str, os.PathLike]
                          ) -> Generator[BedRegion, None, None]:

--- a/src/chunked_scatter/scatter_regions.py
+++ b/src/chunked_scatter/scatter_regions.py
@@ -86,8 +86,11 @@ def argument_parser() -> argparse.ArgumentParser:
         "approximately to the given scatter size.")
     parser.add_argument("-s", "--scatter-size", type=int,
                         default=DEFAULT_SCATTER_SIZE,
-                        help=f"How large the regions over which to scatter "
-                             f"should be. Default: {DEFAULT_SCATTER_SIZE}.")
+                        help=f"The maximum size for the regions over which to "
+                             f"scatter. If contigs are not split, and a "
+                             f"contig is bigger than the maximum size, the "
+                             f"contig will be placed in its own file. "
+                             f"Default: {DEFAULT_SCATTER_SIZE}.")
     return parser
 
 

--- a/src/chunked_scatter/scatter_regions.py
+++ b/src/chunked_scatter/scatter_regions.py
@@ -69,8 +69,9 @@ def scatter_regions(regions: Iterable[BedRegion],
     """
     region_lists = chunked_scatter(regions,
                                    chunk_size=scattersize,
-                                   minimum_base_pairs=scattersize,
+                                   list_size=scattersize,
                                    overlap=0,
+                                   size_is_maximum=True,
                                    contigs_can_be_split=contigs_can_be_split)
     for region_list in region_lists:
         yield list(merge_regions(region_list))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -83,8 +83,9 @@ def test_scatter_regions_main(tmpdir, capsys):
     assert Path(str(tmpdir), "scatters", "scatter-0.bed").exists()
     assert Path(str(tmpdir), "scatters", "scatter-1.bed").exists()
     assert Path(str(tmpdir), "scatters", "scatter-2.bed").exists()
+    assert Path(str(tmpdir), "scatters", "scatter-3.bed").exists()
     assert Path(str(tmpdir), "scatters", "scatter-2.bed").read_text() == (
-        "chr1\t2200000\t3000000\nchr2\t0\t500000\n"
+        "chr1\t2200000\t3000000\n"
     )
     captured = capsys.readouterr()
     assert str(Path(str(tmpdir), "scatters", "scatter-0.bed")) in captured.out

--- a/tests/test_scatter_regions.py
+++ b/tests/test_scatter_regions.py
@@ -43,7 +43,8 @@ def test_adjacent_regions(regions, result):
 
 
 def test_scatter_regions():
-    result = list(scatter_regions(DICT_REGIONS, 1_000_000))
+    result = list(scatter_regions(DICT_REGIONS, 3_200_000))
+    # We should not overflow the scattersize.
     assert result == [
         [BedRegion("chr1", 0, 3_000_000)],
         [BedRegion("chr2", 0, 500_000)]

--- a/tests/test_scatter_regions.py
+++ b/tests/test_scatter_regions.py
@@ -56,6 +56,6 @@ def test_scatter_regions_split_contigs():
     assert result == [
         [BedRegion("chr1", 0, 1_100_000)],
         [BedRegion("chr1", 1_100_000, 2_200_000)],
-        [BedRegion("chr1", 2_200_000, 3_000_000),
-         BedRegion("chr2", 0, 500_000)]
+        [BedRegion("chr1", 2_200_000, 3_000_000)],
+        [BedRegion("chr2", 0, 500_000)]
     ]


### PR DESCRIPTION
Say we have a minimum size of 500 million. chr1 and chr2 together are together almost 500 million. Previously, chromosome 3 of 200 million base pairs was also added. Leading to an overflow of 40%. Because the starting chromosomes are quite large (chromosomes are ordered by size) big overflows are quite common. 

Also, the last scatter file will contain less base pairs than the other files. This is because the last scatter file contains all the remaining chromosomes and there might not be enough to get near the desired size. By using a minimum size the first scatter files can get 40% bigger(as exemplified) which will only amplify the difference.

By using a maximum size this problem is alleviated. Also for the human genome it leads to a much more even distribution for our chosen scatter size default of 1000 million.

### Checklist
- [x] Pull request details were added to HISTORY.rst
